### PR TITLE
Reduce memory usage when print n most large keys

### DIFF
--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -12,7 +12,7 @@ except:
 from rdbtools.parser import RdbCallback
 from rdbtools.encodehelpers import bytes_to_unicode
 
-from heapq import heappush, nlargest, heappop
+from heapq import heappush, nlargest, heappop, heappushpop
 
 ZSKIPLIST_MAXLEVEL=32
 ZSKIPLIST_P=0.25
@@ -93,6 +93,7 @@ class PrintAllKeys(object):
         self._out.write(codecs.encode(headers, 'latin-1'))
 
         if self._largest is not None:
+            self._largest = int(self._largest)
             self._heap = []
     
     def next_record(self, record) :
@@ -106,7 +107,10 @@ class PrintAllKeys(object):
                     record.expiry.isoformat() if record.expiry else '')
                 self._out.write(codecs.encode(rec_str, 'latin-1'))
         else:
-            heappush(self._heap, (record.bytes, record))
+            if len(self._heap) >= self._largest:
+                heappushpop(self._heap, (record.bytes, record))
+            else:
+                heappush(self._heap, (record.bytes, record))
 
     def end_rdb(self):
         if self._largest is not None:


### PR DESCRIPTION
I have a rdb file about 3GB size, and i want to get the n most largest keys.
When i run the rdb tool in k8s pod with 8G memory, the rdb tools was killed due to cgroup memory limit.
The PrintAllKeys would hold all the records in the heap, but in fact we only need n most largest record in the heap.
At the same time, too many record in the heap also cost more cpu when push record in the heap.
After change to n-fixed size heap,  the cost time reduced from 20min to 18min  in my case. 